### PR TITLE
fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A simple html page with a wordcloud might contain:
     <script src="d3.wordcloud.js"></script>
   </head>
   <body>
-    <div id='cloud'></div>
+    <div id='wordcloud'></div>
     <script>
       d3.wordcloud()
         .size([800, 400])

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A simple html page with a wordcloud might contain:
     <script>
       d3.wordcloud()
         .size([800, 400])
-        .selector('#cloud')
+        .selector('#wordcloud')
         .words([{text: 'word', size: 5}, {text: 'cloud', size: 15}])
         .start();
     </script>


### PR DESCRIPTION
A typo in README.md. Pointed by @pecu. It's more proper to use uniform id in example and source code.