### PR TITLE
Fixed bug with non-sorted word arrays.

### DIFF
--- a/d3.wordcloud.js
+++ b/d3.wordcloud.js
@@ -143,6 +143,7 @@
 
     function update() {
       var words = layout.words();
+      words.sort((x, y) => d3.descending(x.size, y.size));
       fontSize = d3.scale[scale]().range([10, 100]);
       if (words.length) {
         fontSize.domain([+words[words.length - 1].size || 1, +words[0].size]);


### PR DESCRIPTION
The word placement algorithms seems to error silently if the word array contains duplicates and isn't sorted, resulting in all words having the same size. For example, try the following word arrays:
```javascript
// Works.
var words = [{text: "foo", size: 20}, 
             {text: "bar", size: 20},
             {text: "baz", size: 10}];
// Doesn't work---all words render the same size.
var words = [{text: "foo", size: 10}, 
             {text: "bar", size: 20},
             {text: "baz", size: 10}];
```
This PR sorts the incoming data in the `update` function to handle this case automatically.